### PR TITLE
A banner stating that v1 is unmaintained, and linking to v2 docs.

### DIFF
--- a/1.0.html
+++ b/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/3rdparty.html
+++ b/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/3rdparty_jvm.html
+++ b/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/3rdparty_py.html
+++ b/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/README.html
+++ b/README.html
@@ -489,7 +489,8 @@ body a.icon-home:hover{
         
       </div>
       &nbsp;
-    </nav>
+      <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
+  </nav>
 
     <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
 

--- a/_site/1.0.html
+++ b/_site/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/3rdparty.html
+++ b/_site/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/3rdparty_jvm.html
+++ b/_site/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/3rdparty_py.html
+++ b/_site/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/alias.html
+++ b/_site/alias.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/announce_201409.html
+++ b/_site/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/build_dictionary.html
+++ b/_site/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/build_files.html
+++ b/_site/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/build_graph_operations.html
+++ b/_site/build_graph_operations.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/bundle.html
+++ b/_site/bundle.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/changelog.html
+++ b/_site/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/clean.html
+++ b/_site/clean.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/cli_args.html
+++ b/_site/cli_args.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/committers.html
+++ b/_site/committers.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/common_tasks.html
+++ b/_site/common_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/community.html
+++ b/_site/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/compile.html
+++ b/_site/compile.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/coursier_migration.html
+++ b/_site/coursier_migration.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/dependencies.html
+++ b/_site/dependencies.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/deprecation_policy.html
+++ b/_site/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/dev.html
+++ b/_site/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/dev_tasks.html
+++ b/_site/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/dev_tasks_publish_extras.html
+++ b/_site/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/docs.html
+++ b/_site/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/export.html
+++ b/_site/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/file_bundles.html
+++ b/_site/file_bundles.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/first_concepts.html
+++ b/_site/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/first_tutorial.html
+++ b/_site/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/from_maven.html
+++ b/_site/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/globs.html
+++ b/_site/globs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/go_readme.html
+++ b/_site/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/howto_ask.html
+++ b/_site/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/howto_contribute.html
+++ b/_site/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/howto_develop.html
+++ b/_site/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/howto_plugin.html
+++ b/_site/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/ide_support.html
+++ b/_site/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/index.html
+++ b/_site/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/install.html
+++ b/_site/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/intellij.html
+++ b/_site/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/internals.html
+++ b/_site/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/invoking.html
+++ b/_site/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/javac_plugins.html
+++ b/_site/javac_plugins.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/jvm_binary.html
+++ b/_site/jvm_binary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/jvm_library.html
+++ b/_site/jvm_library.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/jvm_options.html
+++ b/_site/jvm_options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/jvm_projects.html
+++ b/_site/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/jvm_tests.html
+++ b/_site/jvm_tests.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/list_goals.html
+++ b/_site/list_goals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/list_targets.html
+++ b/_site/list_targets.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/login.html
+++ b/_site/login.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/node_readme.html
+++ b/_site/node_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-1.0.x.html
+++ b/_site/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-1.1.x.html
+++ b/_site/notes-1.1.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-1.10.x.html
+++ b/_site/notes-1.10.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-1.11.x.html
+++ b/_site/notes-1.11.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-1.2.x.html
+++ b/_site/notes-1.2.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-1.3.x.html
+++ b/_site/notes-1.3.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-1.4.x.html
+++ b/_site/notes-1.4.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-1.5.x.html
+++ b/_site/notes-1.5.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-1.6.x.html
+++ b/_site/notes-1.6.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-1.7.x.html
+++ b/_site/notes-1.7.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-1.8.x.html
+++ b/_site/notes-1.8.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-1.9.x.html
+++ b/_site/notes-1.9.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/notes-master.html
+++ b/_site/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/options.html
+++ b/_site/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/options_reference.html
+++ b/_site/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/orgs.html
+++ b/_site/orgs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/page.html
+++ b/_site/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/pex.html
+++ b/_site/pex.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/powered_by.html
+++ b/_site/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/publish.html
+++ b/_site/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/python_library.html
+++ b/_site/python_library.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/python_readme.html
+++ b/_site/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/python_tests.html
+++ b/_site/python_tests.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/release.html
+++ b/_site/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/release_jvm.html
+++ b/_site/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/release_strategy.html
+++ b/_site/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/repl.html
+++ b/_site/repl.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/reporting_server.html
+++ b/_site/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/resources.html
+++ b/_site/resources.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/run.html
+++ b/_site/run.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/scala.html
+++ b/_site/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/scalac_plugins.html
+++ b/_site/scalac_plugins.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/server.html
+++ b/_site/server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/setup_repo.html
+++ b/_site/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/styleguide.html
+++ b/_site/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/target_addresses.html
+++ b/_site/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/test.html
+++ b/_site/test.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/test_suite.html
+++ b/_site/test_suite.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/thrift_deps.html
+++ b/_site/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/thrift_gen.html
+++ b/_site/thrift_gen.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/tshoot.html
+++ b/_site/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/_site/why_use_pants.html
+++ b/_site/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/alias.html
+++ b/alias.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/announce_201409.html
+++ b/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/architecture.html
+++ b/architecture.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/architecture_pantsd.html
+++ b/architecture_pantsd.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/build_dictionary.html
+++ b/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/build_files.html
+++ b/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/build_graph_operations.html
+++ b/build_graph_operations.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/bundle.html
+++ b/bundle.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/changelog.html
+++ b/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/clean.html
+++ b/clean.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/cli_args.html
+++ b/cli_args.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/committers.html
+++ b/committers.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/common_tasks.html
+++ b/common_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/community.html
+++ b/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/compile.html
+++ b/compile.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/coursier_migration.html
+++ b/coursier_migration.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/dependencies.html
+++ b/dependencies.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/deprecation_policy.html
+++ b/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/dev.html
+++ b/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/dev_tasks.html
+++ b/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/dev_tasks_publish_extras.html
+++ b/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/docs.html
+++ b/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/docsite.css
+++ b/docsite.css
@@ -155,6 +155,19 @@ nav.pagetoc ul li.toc-h4 {
   padding-left: 3.0em;
 }
 
+.deprecated {
+  padding: 0.3rem 0;
+  margin: 0;
+  font-size: larger;
+  background-color: lightcoral;
+  text-align: center;
+}
+
+.deprecated a:hover {
+  background-color: lightcoral;
+  color: blue;
+}
+
 div.ci-status {
   position: absolute;
   top: 0;

--- a/export.html
+++ b/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/file_bundles.html
+++ b/file_bundles.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/first_concepts.html
+++ b/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/first_tutorial.html
+++ b/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/from_maven.html
+++ b/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/genindex.html
+++ b/genindex.html
@@ -383,7 +383,8 @@ body a.icon-home:hover{
         
       </div>
       &nbsp;
-    </nav>
+      <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
+  </nav>
 
     <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
 

--- a/globs.html
+++ b/globs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/go_readme.html
+++ b/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/grpcio_gen.html
+++ b/grpcio_gen.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/howto_ask.html
+++ b/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/howto_contribute.html
+++ b/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/howto_customize.html
+++ b/howto_customize.html
@@ -385,7 +385,8 @@ body a.icon-home:hover{
         
       </div>
       &nbsp;
-    </nav>
+      <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
+  </nav>
 
     <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
 

--- a/howto_develop.html
+++ b/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/howto_plugin.html
+++ b/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/ide_support.html
+++ b/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/install.html
+++ b/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/intellij.html
+++ b/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/internals.html
+++ b/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/invoking.html
+++ b/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/javac_plugins.html
+++ b/javac_plugins.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/jvm_binary.html
+++ b/jvm_binary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/jvm_library.html
+++ b/jvm_library.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/jvm_options.html
+++ b/jvm_options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/jvm_projects.html
+++ b/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/jvm_tests.html
+++ b/jvm_tests.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/list_goals.html
+++ b/list_goals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/list_targets.html
+++ b/list_targets.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/login.html
+++ b/login.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/multiple_jvm_versions.html
+++ b/multiple_jvm_versions.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/node_readme.html
+++ b/node_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.0.x.html
+++ b/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.1.x.html
+++ b/notes-1.1.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.10.x.html
+++ b/notes-1.10.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.11.x.html
+++ b/notes-1.11.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.12.x.html
+++ b/notes-1.12.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.13.x.html
+++ b/notes-1.13.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.14.x.html
+++ b/notes-1.14.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.15.x.html
+++ b/notes-1.15.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.16.x.html
+++ b/notes-1.16.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.17.x.html
+++ b/notes-1.17.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.18.x.html
+++ b/notes-1.18.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.19.x.html
+++ b/notes-1.19.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.2.x.html
+++ b/notes-1.2.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.20.x.html
+++ b/notes-1.20.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.21.x.html
+++ b/notes-1.21.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.22.x.html
+++ b/notes-1.22.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.23.x.html
+++ b/notes-1.23.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.24.x.html
+++ b/notes-1.24.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.25.x.html
+++ b/notes-1.25.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.26.x.html
+++ b/notes-1.26.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.27.x.html
+++ b/notes-1.27.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.28.x.html
+++ b/notes-1.28.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.29.x.html
+++ b/notes-1.29.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.3.x.html
+++ b/notes-1.3.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.30.x.html
+++ b/notes-1.30.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.4.x.html
+++ b/notes-1.4.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.5.x.html
+++ b/notes-1.5.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.6.x.html
+++ b/notes-1.6.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.7.x.html
+++ b/notes-1.7.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.8.x.html
+++ b/notes-1.8.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-1.9.x.html
+++ b/notes-1.9.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/notes-master.html
+++ b/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/options.html
+++ b/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/options_reference.html
+++ b/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/orgs.html
+++ b/orgs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/page.html
+++ b/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/pex.html
+++ b/pex.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/powered_by.html
+++ b/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/publish.html
+++ b/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/python_library.html
+++ b/python_library.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/python_readme.html
+++ b/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/python_tests.html
+++ b/python_tests.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/release.html
+++ b/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/release_jvm.html
+++ b/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/release_strategy.html
+++ b/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/repl.html
+++ b/repl.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/reporting_server.html
+++ b/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/resources.html
+++ b/resources.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/run.html
+++ b/run.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/scala.html
+++ b/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/scalac_plugins.html
+++ b/scalac_plugins.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/search.html
+++ b/search.html
@@ -390,7 +390,8 @@ body a.icon-home:hover{
         
       </div>
       &nbsp;
-    </nav>
+      <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
+  </nav>
 
     <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
 

--- a/server.html
+++ b/server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/setup_repo.html
+++ b/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/1.0.html
+++ b/staging/cookbook-test-site/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/3rdparty.html
+++ b/staging/cookbook-test-site/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/3rdparty_jvm.html
+++ b/staging/cookbook-test-site/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/3rdparty_py.html
+++ b/staging/cookbook-test-site/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/announce_201409.html
+++ b/staging/cookbook-test-site/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/build_dictionary.html
+++ b/staging/cookbook-test-site/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/build_files.html
+++ b/staging/cookbook-test-site/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/bundle.html
+++ b/staging/cookbook-test-site/bundle.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/changelog.html
+++ b/staging/cookbook-test-site/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/clean.html
+++ b/staging/cookbook-test-site/clean.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/cli_args.html
+++ b/staging/cookbook-test-site/cli_args.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/committers.html
+++ b/staging/cookbook-test-site/committers.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/common_tasks.html
+++ b/staging/cookbook-test-site/common_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/community.html
+++ b/staging/cookbook-test-site/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/compile.html
+++ b/staging/cookbook-test-site/compile.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/deprecation_policy.html
+++ b/staging/cookbook-test-site/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/dev.html
+++ b/staging/cookbook-test-site/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/dev_tasks.html
+++ b/staging/cookbook-test-site/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/dev_tasks_publish_extras.html
+++ b/staging/cookbook-test-site/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/docs.html
+++ b/staging/cookbook-test-site/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/export.html
+++ b/staging/cookbook-test-site/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/file_bundles.html
+++ b/staging/cookbook-test-site/file_bundles.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/first_concepts.html
+++ b/staging/cookbook-test-site/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/first_tutorial.html
+++ b/staging/cookbook-test-site/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/from_maven.html
+++ b/staging/cookbook-test-site/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/globs.html
+++ b/staging/cookbook-test-site/globs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/go_readme.html
+++ b/staging/cookbook-test-site/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/howto_ask.html
+++ b/staging/cookbook-test-site/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/howto_contribute.html
+++ b/staging/cookbook-test-site/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/howto_develop.html
+++ b/staging/cookbook-test-site/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/howto_plugin.html
+++ b/staging/cookbook-test-site/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/ide_support.html
+++ b/staging/cookbook-test-site/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/index.html
+++ b/staging/cookbook-test-site/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/install.html
+++ b/staging/cookbook-test-site/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/intellij.html
+++ b/staging/cookbook-test-site/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/internals.html
+++ b/staging/cookbook-test-site/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/invoking.html
+++ b/staging/cookbook-test-site/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/jvm_binary.html
+++ b/staging/cookbook-test-site/jvm_binary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/jvm_library.html
+++ b/staging/cookbook-test-site/jvm_library.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/jvm_options.html
+++ b/staging/cookbook-test-site/jvm_options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/jvm_projects.html
+++ b/staging/cookbook-test-site/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/jvm_tests.html
+++ b/staging/cookbook-test-site/jvm_tests.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/list_goals.html
+++ b/staging/cookbook-test-site/list_goals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/list_targets.html
+++ b/staging/cookbook-test-site/list_targets.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/notes-1.0.x.html
+++ b/staging/cookbook-test-site/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/notes-1.1.x.html
+++ b/staging/cookbook-test-site/notes-1.1.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/notes-1.2.x.html
+++ b/staging/cookbook-test-site/notes-1.2.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/notes-master.html
+++ b/staging/cookbook-test-site/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/options.html
+++ b/staging/cookbook-test-site/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/options_reference.html
+++ b/staging/cookbook-test-site/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/page.html
+++ b/staging/cookbook-test-site/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/pex.html
+++ b/staging/cookbook-test-site/pex.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/powered_by.html
+++ b/staging/cookbook-test-site/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/publish.html
+++ b/staging/cookbook-test-site/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/python_library.html
+++ b/staging/cookbook-test-site/python_library.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/python_readme.html
+++ b/staging/cookbook-test-site/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/python_tests.html
+++ b/staging/cookbook-test-site/python_tests.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/release.html
+++ b/staging/cookbook-test-site/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/release_jvm.html
+++ b/staging/cookbook-test-site/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/release_strategy.html
+++ b/staging/cookbook-test-site/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/repl.html
+++ b/staging/cookbook-test-site/repl.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/reporting_server.html
+++ b/staging/cookbook-test-site/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/resources.html
+++ b/staging/cookbook-test-site/resources.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/run.html
+++ b/staging/cookbook-test-site/run.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/scala.html
+++ b/staging/cookbook-test-site/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/server.html
+++ b/staging/cookbook-test-site/server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/setup_repo.html
+++ b/staging/cookbook-test-site/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/styleguide.html
+++ b/staging/cookbook-test-site/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/target_addresses.html
+++ b/staging/cookbook-test-site/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/test.html
+++ b/staging/cookbook-test-site/test.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/test_suite.html
+++ b/staging/cookbook-test-site/test_suite.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/thrift_deps.html
+++ b/staging/cookbook-test-site/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/thrift_gen.html
+++ b/staging/cookbook-test-site/thrift_gen.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/tshoot.html
+++ b/staging/cookbook-test-site/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/cookbook-test-site/why_use_pants.html
+++ b/staging/cookbook-test-site/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/1.0.html
+++ b/staging/jsirois/dev-notes/pants-from-source/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/3rdparty.html
+++ b/staging/jsirois/dev-notes/pants-from-source/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/3rdparty_jvm.html
+++ b/staging/jsirois/dev-notes/pants-from-source/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/3rdparty_py.html
+++ b/staging/jsirois/dev-notes/pants-from-source/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/announce_201409.html
+++ b/staging/jsirois/dev-notes/pants-from-source/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/branching_strategy.html
+++ b/staging/jsirois/dev-notes/pants-from-source/branching_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/build_dictionary.html
+++ b/staging/jsirois/dev-notes/pants-from-source/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/build_files.html
+++ b/staging/jsirois/dev-notes/pants-from-source/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/changelog.html
+++ b/staging/jsirois/dev-notes/pants-from-source/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/community.html
+++ b/staging/jsirois/dev-notes/pants-from-source/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/deprecation_policy.html
+++ b/staging/jsirois/dev-notes/pants-from-source/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/dev.html
+++ b/staging/jsirois/dev-notes/pants-from-source/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/dev_tasks.html
+++ b/staging/jsirois/dev-notes/pants-from-source/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/dev_tasks_publish_extras.html
+++ b/staging/jsirois/dev-notes/pants-from-source/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/docs.html
+++ b/staging/jsirois/dev-notes/pants-from-source/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/export.html
+++ b/staging/jsirois/dev-notes/pants-from-source/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/first_concepts.html
+++ b/staging/jsirois/dev-notes/pants-from-source/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/first_tutorial.html
+++ b/staging/jsirois/dev-notes/pants-from-source/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/from_maven.html
+++ b/staging/jsirois/dev-notes/pants-from-source/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/howto_ask.html
+++ b/staging/jsirois/dev-notes/pants-from-source/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/howto_contribute.html
+++ b/staging/jsirois/dev-notes/pants-from-source/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/howto_develop.html
+++ b/staging/jsirois/dev-notes/pants-from-source/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/howto_plugin.html
+++ b/staging/jsirois/dev-notes/pants-from-source/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/ide_support.html
+++ b/staging/jsirois/dev-notes/pants-from-source/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/index.html
+++ b/staging/jsirois/dev-notes/pants-from-source/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/install.html
+++ b/staging/jsirois/dev-notes/pants-from-source/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/intellij.html
+++ b/staging/jsirois/dev-notes/pants-from-source/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/internals.html
+++ b/staging/jsirois/dev-notes/pants-from-source/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/invoking.html
+++ b/staging/jsirois/dev-notes/pants-from-source/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/jvm_projects.html
+++ b/staging/jsirois/dev-notes/pants-from-source/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/options.html
+++ b/staging/jsirois/dev-notes/pants-from-source/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/options_reference.html
+++ b/staging/jsirois/dev-notes/pants-from-source/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/page.html
+++ b/staging/jsirois/dev-notes/pants-from-source/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/powered_by.html
+++ b/staging/jsirois/dev-notes/pants-from-source/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/publish.html
+++ b/staging/jsirois/dev-notes/pants-from-source/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/python_readme.html
+++ b/staging/jsirois/dev-notes/pants-from-source/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/release.html
+++ b/staging/jsirois/dev-notes/pants-from-source/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/release_jvm.html
+++ b/staging/jsirois/dev-notes/pants-from-source/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/reporting_server.html
+++ b/staging/jsirois/dev-notes/pants-from-source/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/scala.html
+++ b/staging/jsirois/dev-notes/pants-from-source/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/setup_repo.html
+++ b/staging/jsirois/dev-notes/pants-from-source/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/styleguide.html
+++ b/staging/jsirois/dev-notes/pants-from-source/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/target_addresses.html
+++ b/staging/jsirois/dev-notes/pants-from-source/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/thrift_deps.html
+++ b/staging/jsirois/dev-notes/pants-from-source/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/tshoot.html
+++ b/staging/jsirois/dev-notes/pants-from-source/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/dev-notes/pants-from-source/why_use_pants.html
+++ b/staging/jsirois/dev-notes/pants-from-source/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/1.0.html
+++ b/staging/jsirois/issues/3545/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/3rdparty.html
+++ b/staging/jsirois/issues/3545/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/3rdparty_jvm.html
+++ b/staging/jsirois/issues/3545/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/3rdparty_py.html
+++ b/staging/jsirois/issues/3545/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/announce_201409.html
+++ b/staging/jsirois/issues/3545/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/build_dictionary.html
+++ b/staging/jsirois/issues/3545/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/build_files.html
+++ b/staging/jsirois/issues/3545/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/changelog.html
+++ b/staging/jsirois/issues/3545/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/community.html
+++ b/staging/jsirois/issues/3545/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/deprecation_policy.html
+++ b/staging/jsirois/issues/3545/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/dev.html
+++ b/staging/jsirois/issues/3545/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/dev_tasks.html
+++ b/staging/jsirois/issues/3545/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/dev_tasks_publish_extras.html
+++ b/staging/jsirois/issues/3545/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/docs.html
+++ b/staging/jsirois/issues/3545/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/export.html
+++ b/staging/jsirois/issues/3545/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/first_concepts.html
+++ b/staging/jsirois/issues/3545/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/first_tutorial.html
+++ b/staging/jsirois/issues/3545/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/from_maven.html
+++ b/staging/jsirois/issues/3545/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/go_readme.html
+++ b/staging/jsirois/issues/3545/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/howto_ask.html
+++ b/staging/jsirois/issues/3545/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/howto_contribute.html
+++ b/staging/jsirois/issues/3545/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/howto_develop.html
+++ b/staging/jsirois/issues/3545/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/howto_plugin.html
+++ b/staging/jsirois/issues/3545/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/ide_support.html
+++ b/staging/jsirois/issues/3545/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/index.html
+++ b/staging/jsirois/issues/3545/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/install.html
+++ b/staging/jsirois/issues/3545/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/intellij.html
+++ b/staging/jsirois/issues/3545/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/internals.html
+++ b/staging/jsirois/issues/3545/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/invoking.html
+++ b/staging/jsirois/issues/3545/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/jvm_projects.html
+++ b/staging/jsirois/issues/3545/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/notes-1.0.x.html
+++ b/staging/jsirois/issues/3545/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/notes-master.html
+++ b/staging/jsirois/issues/3545/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/options.html
+++ b/staging/jsirois/issues/3545/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/options_reference.html
+++ b/staging/jsirois/issues/3545/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/page.html
+++ b/staging/jsirois/issues/3545/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/powered_by.html
+++ b/staging/jsirois/issues/3545/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/publish.html
+++ b/staging/jsirois/issues/3545/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/python_readme.html
+++ b/staging/jsirois/issues/3545/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/release.html
+++ b/staging/jsirois/issues/3545/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/release_jvm.html
+++ b/staging/jsirois/issues/3545/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/release_strategy.html
+++ b/staging/jsirois/issues/3545/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/reporting_server.html
+++ b/staging/jsirois/issues/3545/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/scala.html
+++ b/staging/jsirois/issues/3545/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/setup_repo.html
+++ b/staging/jsirois/issues/3545/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/styleguide.html
+++ b/staging/jsirois/issues/3545/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/target_addresses.html
+++ b/staging/jsirois/issues/3545/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/thrift_deps.html
+++ b/staging/jsirois/issues/3545/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/tshoot.html
+++ b/staging/jsirois/issues/3545/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3545/why_use_pants.html
+++ b/staging/jsirois/issues/3545/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/1.0.html
+++ b/staging/jsirois/issues/3877/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/3rdparty.html
+++ b/staging/jsirois/issues/3877/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/3rdparty_jvm.html
+++ b/staging/jsirois/issues/3877/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/3rdparty_py.html
+++ b/staging/jsirois/issues/3877/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/announce_201409.html
+++ b/staging/jsirois/issues/3877/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/build_dictionary.html
+++ b/staging/jsirois/issues/3877/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/build_files.html
+++ b/staging/jsirois/issues/3877/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/changelog.html
+++ b/staging/jsirois/issues/3877/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/committers.html
+++ b/staging/jsirois/issues/3877/committers.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/community.html
+++ b/staging/jsirois/issues/3877/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/deprecation_policy.html
+++ b/staging/jsirois/issues/3877/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/dev.html
+++ b/staging/jsirois/issues/3877/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/dev_tasks.html
+++ b/staging/jsirois/issues/3877/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/dev_tasks_publish_extras.html
+++ b/staging/jsirois/issues/3877/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/docs.html
+++ b/staging/jsirois/issues/3877/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/export.html
+++ b/staging/jsirois/issues/3877/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/first_concepts.html
+++ b/staging/jsirois/issues/3877/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/first_tutorial.html
+++ b/staging/jsirois/issues/3877/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/from_maven.html
+++ b/staging/jsirois/issues/3877/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/go_readme.html
+++ b/staging/jsirois/issues/3877/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/howto_ask.html
+++ b/staging/jsirois/issues/3877/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/howto_contribute.html
+++ b/staging/jsirois/issues/3877/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/howto_develop.html
+++ b/staging/jsirois/issues/3877/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/howto_plugin.html
+++ b/staging/jsirois/issues/3877/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/ide_support.html
+++ b/staging/jsirois/issues/3877/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/index.html
+++ b/staging/jsirois/issues/3877/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/install.html
+++ b/staging/jsirois/issues/3877/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/intellij.html
+++ b/staging/jsirois/issues/3877/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/internals.html
+++ b/staging/jsirois/issues/3877/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/invoking.html
+++ b/staging/jsirois/issues/3877/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/jvm_projects.html
+++ b/staging/jsirois/issues/3877/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/notes-1.0.x.html
+++ b/staging/jsirois/issues/3877/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/notes-1.1.x.html
+++ b/staging/jsirois/issues/3877/notes-1.1.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/notes-master.html
+++ b/staging/jsirois/issues/3877/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/options.html
+++ b/staging/jsirois/issues/3877/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/options_reference.html
+++ b/staging/jsirois/issues/3877/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/page.html
+++ b/staging/jsirois/issues/3877/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/powered_by.html
+++ b/staging/jsirois/issues/3877/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/publish.html
+++ b/staging/jsirois/issues/3877/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/python_readme.html
+++ b/staging/jsirois/issues/3877/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/release.html
+++ b/staging/jsirois/issues/3877/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/release_jvm.html
+++ b/staging/jsirois/issues/3877/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/release_strategy.html
+++ b/staging/jsirois/issues/3877/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/reporting_server.html
+++ b/staging/jsirois/issues/3877/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/scala.html
+++ b/staging/jsirois/issues/3877/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/setup_repo.html
+++ b/staging/jsirois/issues/3877/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/styleguide.html
+++ b/staging/jsirois/issues/3877/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/target_addresses.html
+++ b/staging/jsirois/issues/3877/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/thrift_deps.html
+++ b/staging/jsirois/issues/3877/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/tshoot.html
+++ b/staging/jsirois/issues/3877/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/issues/3877/why_use_pants.html
+++ b/staging/jsirois/issues/3877/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/1.0.html
+++ b/staging/jsirois/mox/eliminate/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/3rdparty.html
+++ b/staging/jsirois/mox/eliminate/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/3rdparty_jvm.html
+++ b/staging/jsirois/mox/eliminate/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/3rdparty_py.html
+++ b/staging/jsirois/mox/eliminate/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/announce_201409.html
+++ b/staging/jsirois/mox/eliminate/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/build_dictionary.html
+++ b/staging/jsirois/mox/eliminate/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/build_files.html
+++ b/staging/jsirois/mox/eliminate/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/changelog.html
+++ b/staging/jsirois/mox/eliminate/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/committers.html
+++ b/staging/jsirois/mox/eliminate/committers.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/community.html
+++ b/staging/jsirois/mox/eliminate/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/deprecation_policy.html
+++ b/staging/jsirois/mox/eliminate/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/dev.html
+++ b/staging/jsirois/mox/eliminate/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/dev_tasks.html
+++ b/staging/jsirois/mox/eliminate/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/dev_tasks_publish_extras.html
+++ b/staging/jsirois/mox/eliminate/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/docs.html
+++ b/staging/jsirois/mox/eliminate/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/export.html
+++ b/staging/jsirois/mox/eliminate/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/first_concepts.html
+++ b/staging/jsirois/mox/eliminate/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/first_tutorial.html
+++ b/staging/jsirois/mox/eliminate/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/from_maven.html
+++ b/staging/jsirois/mox/eliminate/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/go_readme.html
+++ b/staging/jsirois/mox/eliminate/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/howto_ask.html
+++ b/staging/jsirois/mox/eliminate/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/howto_contribute.html
+++ b/staging/jsirois/mox/eliminate/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/howto_develop.html
+++ b/staging/jsirois/mox/eliminate/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/howto_plugin.html
+++ b/staging/jsirois/mox/eliminate/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/ide_support.html
+++ b/staging/jsirois/mox/eliminate/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/index.html
+++ b/staging/jsirois/mox/eliminate/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/install.html
+++ b/staging/jsirois/mox/eliminate/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/intellij.html
+++ b/staging/jsirois/mox/eliminate/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/internals.html
+++ b/staging/jsirois/mox/eliminate/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/invoking.html
+++ b/staging/jsirois/mox/eliminate/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/jvm_projects.html
+++ b/staging/jsirois/mox/eliminate/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/notes-1.0.x.html
+++ b/staging/jsirois/mox/eliminate/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/notes-1.1.x.html
+++ b/staging/jsirois/mox/eliminate/notes-1.1.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/notes-master.html
+++ b/staging/jsirois/mox/eliminate/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/options.html
+++ b/staging/jsirois/mox/eliminate/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/options_reference.html
+++ b/staging/jsirois/mox/eliminate/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/page.html
+++ b/staging/jsirois/mox/eliminate/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/powered_by.html
+++ b/staging/jsirois/mox/eliminate/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/publish.html
+++ b/staging/jsirois/mox/eliminate/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/python_readme.html
+++ b/staging/jsirois/mox/eliminate/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/release.html
+++ b/staging/jsirois/mox/eliminate/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/release_jvm.html
+++ b/staging/jsirois/mox/eliminate/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/release_strategy.html
+++ b/staging/jsirois/mox/eliminate/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/reporting_server.html
+++ b/staging/jsirois/mox/eliminate/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/scala.html
+++ b/staging/jsirois/mox/eliminate/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/setup_repo.html
+++ b/staging/jsirois/mox/eliminate/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/styleguide.html
+++ b/staging/jsirois/mox/eliminate/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/target_addresses.html
+++ b/staging/jsirois/mox/eliminate/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/thrift_deps.html
+++ b/staging/jsirois/mox/eliminate/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/tshoot.html
+++ b/staging/jsirois/mox/eliminate/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/mox/eliminate/why_use_pants.html
+++ b/staging/jsirois/mox/eliminate/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/1.0.html
+++ b/staging/jsirois/resource_targets/doc/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/3rdparty.html
+++ b/staging/jsirois/resource_targets/doc/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/3rdparty_jvm.html
+++ b/staging/jsirois/resource_targets/doc/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/3rdparty_py.html
+++ b/staging/jsirois/resource_targets/doc/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/announce_201409.html
+++ b/staging/jsirois/resource_targets/doc/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/build_dictionary.html
+++ b/staging/jsirois/resource_targets/doc/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/build_files.html
+++ b/staging/jsirois/resource_targets/doc/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/changelog.html
+++ b/staging/jsirois/resource_targets/doc/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/committers.html
+++ b/staging/jsirois/resource_targets/doc/committers.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/community.html
+++ b/staging/jsirois/resource_targets/doc/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/deprecation_policy.html
+++ b/staging/jsirois/resource_targets/doc/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/dev.html
+++ b/staging/jsirois/resource_targets/doc/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/dev_tasks.html
+++ b/staging/jsirois/resource_targets/doc/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/dev_tasks_publish_extras.html
+++ b/staging/jsirois/resource_targets/doc/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/docs.html
+++ b/staging/jsirois/resource_targets/doc/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/export.html
+++ b/staging/jsirois/resource_targets/doc/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/first_concepts.html
+++ b/staging/jsirois/resource_targets/doc/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/first_tutorial.html
+++ b/staging/jsirois/resource_targets/doc/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/from_maven.html
+++ b/staging/jsirois/resource_targets/doc/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/go_readme.html
+++ b/staging/jsirois/resource_targets/doc/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/howto_ask.html
+++ b/staging/jsirois/resource_targets/doc/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/howto_contribute.html
+++ b/staging/jsirois/resource_targets/doc/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/howto_develop.html
+++ b/staging/jsirois/resource_targets/doc/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/howto_plugin.html
+++ b/staging/jsirois/resource_targets/doc/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/ide_support.html
+++ b/staging/jsirois/resource_targets/doc/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/index.html
+++ b/staging/jsirois/resource_targets/doc/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/install.html
+++ b/staging/jsirois/resource_targets/doc/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/intellij.html
+++ b/staging/jsirois/resource_targets/doc/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/internals.html
+++ b/staging/jsirois/resource_targets/doc/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/invoking.html
+++ b/staging/jsirois/resource_targets/doc/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/jvm_projects.html
+++ b/staging/jsirois/resource_targets/doc/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/notes-1.0.x.html
+++ b/staging/jsirois/resource_targets/doc/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/notes-1.1.x.html
+++ b/staging/jsirois/resource_targets/doc/notes-1.1.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/notes-master.html
+++ b/staging/jsirois/resource_targets/doc/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/options.html
+++ b/staging/jsirois/resource_targets/doc/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/options_reference.html
+++ b/staging/jsirois/resource_targets/doc/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/page.html
+++ b/staging/jsirois/resource_targets/doc/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/powered_by.html
+++ b/staging/jsirois/resource_targets/doc/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/publish.html
+++ b/staging/jsirois/resource_targets/doc/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/python_readme.html
+++ b/staging/jsirois/resource_targets/doc/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/release.html
+++ b/staging/jsirois/resource_targets/doc/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/release_jvm.html
+++ b/staging/jsirois/resource_targets/doc/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/release_strategy.html
+++ b/staging/jsirois/resource_targets/doc/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/reporting_server.html
+++ b/staging/jsirois/resource_targets/doc/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/scala.html
+++ b/staging/jsirois/resource_targets/doc/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/setup_repo.html
+++ b/staging/jsirois/resource_targets/doc/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/styleguide.html
+++ b/staging/jsirois/resource_targets/doc/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/target_addresses.html
+++ b/staging/jsirois/resource_targets/doc/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/thrift_deps.html
+++ b/staging/jsirois/resource_targets/doc/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/tshoot.html
+++ b/staging/jsirois/resource_targets/doc/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/jsirois/resource_targets/doc/why_use_pants.html
+++ b/staging/jsirois/resource_targets/doc/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/1.0.html
+++ b/staging/nhoward-test-site/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/3rdparty.html
+++ b/staging/nhoward-test-site/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/3rdparty_jvm.html
+++ b/staging/nhoward-test-site/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/3rdparty_py.html
+++ b/staging/nhoward-test-site/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/alias.html
+++ b/staging/nhoward-test-site/alias.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/announce_201409.html
+++ b/staging/nhoward-test-site/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/build_dictionary.html
+++ b/staging/nhoward-test-site/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/build_files.html
+++ b/staging/nhoward-test-site/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/bundle.html
+++ b/staging/nhoward-test-site/bundle.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/changelog.html
+++ b/staging/nhoward-test-site/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/clean.html
+++ b/staging/nhoward-test-site/clean.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/cli_args.html
+++ b/staging/nhoward-test-site/cli_args.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/committers.html
+++ b/staging/nhoward-test-site/committers.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/common_tasks.html
+++ b/staging/nhoward-test-site/common_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/community.html
+++ b/staging/nhoward-test-site/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/compile.html
+++ b/staging/nhoward-test-site/compile.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/coursier_migration.html
+++ b/staging/nhoward-test-site/coursier_migration.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/dependencies.html
+++ b/staging/nhoward-test-site/dependencies.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/deprecation_policy.html
+++ b/staging/nhoward-test-site/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/dev.html
+++ b/staging/nhoward-test-site/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/dev_tasks.html
+++ b/staging/nhoward-test-site/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/dev_tasks_publish_extras.html
+++ b/staging/nhoward-test-site/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/docs.html
+++ b/staging/nhoward-test-site/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/export.html
+++ b/staging/nhoward-test-site/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/file_bundles.html
+++ b/staging/nhoward-test-site/file_bundles.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/first_concepts.html
+++ b/staging/nhoward-test-site/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/first_tutorial.html
+++ b/staging/nhoward-test-site/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/from_maven.html
+++ b/staging/nhoward-test-site/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/globs.html
+++ b/staging/nhoward-test-site/globs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/go_readme.html
+++ b/staging/nhoward-test-site/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/howto_ask.html
+++ b/staging/nhoward-test-site/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/howto_contribute.html
+++ b/staging/nhoward-test-site/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/howto_develop.html
+++ b/staging/nhoward-test-site/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/howto_plugin.html
+++ b/staging/nhoward-test-site/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/ide_support.html
+++ b/staging/nhoward-test-site/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/index.html
+++ b/staging/nhoward-test-site/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/install.html
+++ b/staging/nhoward-test-site/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/intellij.html
+++ b/staging/nhoward-test-site/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/internals.html
+++ b/staging/nhoward-test-site/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/invoking.html
+++ b/staging/nhoward-test-site/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/javac_plugins.html
+++ b/staging/nhoward-test-site/javac_plugins.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/jvm_binary.html
+++ b/staging/nhoward-test-site/jvm_binary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/jvm_library.html
+++ b/staging/nhoward-test-site/jvm_library.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/jvm_options.html
+++ b/staging/nhoward-test-site/jvm_options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/jvm_projects.html
+++ b/staging/nhoward-test-site/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/jvm_tests.html
+++ b/staging/nhoward-test-site/jvm_tests.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/list_goals.html
+++ b/staging/nhoward-test-site/list_goals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/list_targets.html
+++ b/staging/nhoward-test-site/list_targets.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/login.html
+++ b/staging/nhoward-test-site/login.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/node_readme.html
+++ b/staging/nhoward-test-site/node_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.0.x.html
+++ b/staging/nhoward-test-site/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.1.x.html
+++ b/staging/nhoward-test-site/notes-1.1.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.10.x.html
+++ b/staging/nhoward-test-site/notes-1.10.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.11.x.html
+++ b/staging/nhoward-test-site/notes-1.11.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.12.x.html
+++ b/staging/nhoward-test-site/notes-1.12.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.2.x.html
+++ b/staging/nhoward-test-site/notes-1.2.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.3.x.html
+++ b/staging/nhoward-test-site/notes-1.3.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.4.x.html
+++ b/staging/nhoward-test-site/notes-1.4.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.5.x.html
+++ b/staging/nhoward-test-site/notes-1.5.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.6.x.html
+++ b/staging/nhoward-test-site/notes-1.6.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.7.x.html
+++ b/staging/nhoward-test-site/notes-1.7.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.8.x.html
+++ b/staging/nhoward-test-site/notes-1.8.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-1.9.x.html
+++ b/staging/nhoward-test-site/notes-1.9.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/notes-master.html
+++ b/staging/nhoward-test-site/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/options.html
+++ b/staging/nhoward-test-site/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/options_reference.html
+++ b/staging/nhoward-test-site/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/orgs.html
+++ b/staging/nhoward-test-site/orgs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/page.html
+++ b/staging/nhoward-test-site/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/pex.html
+++ b/staging/nhoward-test-site/pex.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/powered_by.html
+++ b/staging/nhoward-test-site/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/publish.html
+++ b/staging/nhoward-test-site/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/python_library.html
+++ b/staging/nhoward-test-site/python_library.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/python_readme.html
+++ b/staging/nhoward-test-site/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/python_tests.html
+++ b/staging/nhoward-test-site/python_tests.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/release.html
+++ b/staging/nhoward-test-site/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/release_jvm.html
+++ b/staging/nhoward-test-site/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/release_strategy.html
+++ b/staging/nhoward-test-site/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/repl.html
+++ b/staging/nhoward-test-site/repl.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/reporting_server.html
+++ b/staging/nhoward-test-site/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/resources.html
+++ b/staging/nhoward-test-site/resources.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/run.html
+++ b/staging/nhoward-test-site/run.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/scala.html
+++ b/staging/nhoward-test-site/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/scalac_plugins.html
+++ b/staging/nhoward-test-site/scalac_plugins.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/server.html
+++ b/staging/nhoward-test-site/server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/setup_repo.html
+++ b/staging/nhoward-test-site/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/styleguide.html
+++ b/staging/nhoward-test-site/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/target_addresses.html
+++ b/staging/nhoward-test-site/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/test.html
+++ b/staging/nhoward-test-site/test.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/test_suite.html
+++ b/staging/nhoward-test-site/test_suite.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/thrift_deps.html
+++ b/staging/nhoward-test-site/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/thrift_gen.html
+++ b/staging/nhoward-test-site/thrift_gen.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/tshoot.html
+++ b/staging/nhoward-test-site/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test-site/why_use_pants.html
+++ b/staging/nhoward-test-site/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/1.0.html
+++ b/staging/nhoward-test/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/3rdparty.html
+++ b/staging/nhoward-test/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/3rdparty_jvm.html
+++ b/staging/nhoward-test/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/3rdparty_py.html
+++ b/staging/nhoward-test/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/announce_201409.html
+++ b/staging/nhoward-test/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/build_dictionary.html
+++ b/staging/nhoward-test/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/build_files.html
+++ b/staging/nhoward-test/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/changelog.html
+++ b/staging/nhoward-test/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/committers.html
+++ b/staging/nhoward-test/committers.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/community.html
+++ b/staging/nhoward-test/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/deprecation_policy.html
+++ b/staging/nhoward-test/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/dev.html
+++ b/staging/nhoward-test/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/dev_tasks.html
+++ b/staging/nhoward-test/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/dev_tasks_publish_extras.html
+++ b/staging/nhoward-test/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/docs.html
+++ b/staging/nhoward-test/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/export.html
+++ b/staging/nhoward-test/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/first_concepts.html
+++ b/staging/nhoward-test/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/first_tutorial.html
+++ b/staging/nhoward-test/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/from_maven.html
+++ b/staging/nhoward-test/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/go_readme.html
+++ b/staging/nhoward-test/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/howto_ask.html
+++ b/staging/nhoward-test/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/howto_contribute.html
+++ b/staging/nhoward-test/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/howto_develop.html
+++ b/staging/nhoward-test/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/howto_plugin.html
+++ b/staging/nhoward-test/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/ide_support.html
+++ b/staging/nhoward-test/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/index.html
+++ b/staging/nhoward-test/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/install.html
+++ b/staging/nhoward-test/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/intellij.html
+++ b/staging/nhoward-test/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/internals.html
+++ b/staging/nhoward-test/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/invoking.html
+++ b/staging/nhoward-test/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/jvm_projects.html
+++ b/staging/nhoward-test/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/notes-1.0.x.html
+++ b/staging/nhoward-test/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/notes-1.1.x.html
+++ b/staging/nhoward-test/notes-1.1.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/notes-1.2.x.html
+++ b/staging/nhoward-test/notes-1.2.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/notes-master.html
+++ b/staging/nhoward-test/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/options.html
+++ b/staging/nhoward-test/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/options_reference.html
+++ b/staging/nhoward-test/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/page.html
+++ b/staging/nhoward-test/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/powered_by.html
+++ b/staging/nhoward-test/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/publish.html
+++ b/staging/nhoward-test/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/python_readme.html
+++ b/staging/nhoward-test/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/release.html
+++ b/staging/nhoward-test/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/release_jvm.html
+++ b/staging/nhoward-test/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/release_strategy.html
+++ b/staging/nhoward-test/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/reporting_server.html
+++ b/staging/nhoward-test/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/scala.html
+++ b/staging/nhoward-test/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/setup_repo.html
+++ b/staging/nhoward-test/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/styleguide.html
+++ b/staging/nhoward-test/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/target_addresses.html
+++ b/staging/nhoward-test/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/thrift_deps.html
+++ b/staging/nhoward-test/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/tshoot.html
+++ b/staging/nhoward-test/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/nhoward-test/why_use_pants.html
+++ b/staging/nhoward-test/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/1.0.html
+++ b/staging/stuhood-fixup-1.1.x/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/3rdparty.html
+++ b/staging/stuhood-fixup-1.1.x/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/3rdparty_jvm.html
+++ b/staging/stuhood-fixup-1.1.x/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/3rdparty_py.html
+++ b/staging/stuhood-fixup-1.1.x/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/announce_201409.html
+++ b/staging/stuhood-fixup-1.1.x/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/build_dictionary.html
+++ b/staging/stuhood-fixup-1.1.x/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/build_files.html
+++ b/staging/stuhood-fixup-1.1.x/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/changelog.html
+++ b/staging/stuhood-fixup-1.1.x/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/community.html
+++ b/staging/stuhood-fixup-1.1.x/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/deprecation_policy.html
+++ b/staging/stuhood-fixup-1.1.x/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/dev.html
+++ b/staging/stuhood-fixup-1.1.x/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/dev_tasks.html
+++ b/staging/stuhood-fixup-1.1.x/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/dev_tasks_publish_extras.html
+++ b/staging/stuhood-fixup-1.1.x/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/docs.html
+++ b/staging/stuhood-fixup-1.1.x/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/export.html
+++ b/staging/stuhood-fixup-1.1.x/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/first_concepts.html
+++ b/staging/stuhood-fixup-1.1.x/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/first_tutorial.html
+++ b/staging/stuhood-fixup-1.1.x/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/from_maven.html
+++ b/staging/stuhood-fixup-1.1.x/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/go_readme.html
+++ b/staging/stuhood-fixup-1.1.x/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/howto_ask.html
+++ b/staging/stuhood-fixup-1.1.x/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/howto_contribute.html
+++ b/staging/stuhood-fixup-1.1.x/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/howto_develop.html
+++ b/staging/stuhood-fixup-1.1.x/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/howto_plugin.html
+++ b/staging/stuhood-fixup-1.1.x/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/ide_support.html
+++ b/staging/stuhood-fixup-1.1.x/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/index.html
+++ b/staging/stuhood-fixup-1.1.x/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/install.html
+++ b/staging/stuhood-fixup-1.1.x/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/intellij.html
+++ b/staging/stuhood-fixup-1.1.x/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/internals.html
+++ b/staging/stuhood-fixup-1.1.x/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/invoking.html
+++ b/staging/stuhood-fixup-1.1.x/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/jvm_projects.html
+++ b/staging/stuhood-fixup-1.1.x/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/notes-1.0.x.html
+++ b/staging/stuhood-fixup-1.1.x/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/notes-1.1.x.html
+++ b/staging/stuhood-fixup-1.1.x/notes-1.1.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/notes-master.html
+++ b/staging/stuhood-fixup-1.1.x/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/options.html
+++ b/staging/stuhood-fixup-1.1.x/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/options_reference.html
+++ b/staging/stuhood-fixup-1.1.x/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/page.html
+++ b/staging/stuhood-fixup-1.1.x/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/powered_by.html
+++ b/staging/stuhood-fixup-1.1.x/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/publish.html
+++ b/staging/stuhood-fixup-1.1.x/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/python_readme.html
+++ b/staging/stuhood-fixup-1.1.x/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/release.html
+++ b/staging/stuhood-fixup-1.1.x/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/release_jvm.html
+++ b/staging/stuhood-fixup-1.1.x/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/release_strategy.html
+++ b/staging/stuhood-fixup-1.1.x/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/reporting_server.html
+++ b/staging/stuhood-fixup-1.1.x/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/scala.html
+++ b/staging/stuhood-fixup-1.1.x/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/setup_repo.html
+++ b/staging/stuhood-fixup-1.1.x/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/styleguide.html
+++ b/staging/stuhood-fixup-1.1.x/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/target_addresses.html
+++ b/staging/stuhood-fixup-1.1.x/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/thrift_deps.html
+++ b/staging/stuhood-fixup-1.1.x/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/tshoot.html
+++ b/staging/stuhood-fixup-1.1.x/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-fixup-1.1.x/why_use_pants.html
+++ b/staging/stuhood-fixup-1.1.x/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/1.0.html
+++ b/staging/stuhood-release-notes-per-branch/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/3rdparty.html
+++ b/staging/stuhood-release-notes-per-branch/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/3rdparty_jvm.html
+++ b/staging/stuhood-release-notes-per-branch/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/3rdparty_py.html
+++ b/staging/stuhood-release-notes-per-branch/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/announce_201409.html
+++ b/staging/stuhood-release-notes-per-branch/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/branching_strategy.html
+++ b/staging/stuhood-release-notes-per-branch/branching_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/build_dictionary.html
+++ b/staging/stuhood-release-notes-per-branch/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/build_files.html
+++ b/staging/stuhood-release-notes-per-branch/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/changelog.html
+++ b/staging/stuhood-release-notes-per-branch/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/community.html
+++ b/staging/stuhood-release-notes-per-branch/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/deprecation_policy.html
+++ b/staging/stuhood-release-notes-per-branch/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/dev.html
+++ b/staging/stuhood-release-notes-per-branch/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/dev_tasks.html
+++ b/staging/stuhood-release-notes-per-branch/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/dev_tasks_publish_extras.html
+++ b/staging/stuhood-release-notes-per-branch/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/docs.html
+++ b/staging/stuhood-release-notes-per-branch/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/export.html
+++ b/staging/stuhood-release-notes-per-branch/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/first_concepts.html
+++ b/staging/stuhood-release-notes-per-branch/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/first_tutorial.html
+++ b/staging/stuhood-release-notes-per-branch/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/from_maven.html
+++ b/staging/stuhood-release-notes-per-branch/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/go_readme.html
+++ b/staging/stuhood-release-notes-per-branch/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/howto_ask.html
+++ b/staging/stuhood-release-notes-per-branch/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/howto_contribute.html
+++ b/staging/stuhood-release-notes-per-branch/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/howto_develop.html
+++ b/staging/stuhood-release-notes-per-branch/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/howto_plugin.html
+++ b/staging/stuhood-release-notes-per-branch/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/ide_support.html
+++ b/staging/stuhood-release-notes-per-branch/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/index.html
+++ b/staging/stuhood-release-notes-per-branch/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/install.html
+++ b/staging/stuhood-release-notes-per-branch/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/intellij.html
+++ b/staging/stuhood-release-notes-per-branch/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/internals.html
+++ b/staging/stuhood-release-notes-per-branch/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/invoking.html
+++ b/staging/stuhood-release-notes-per-branch/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/jvm_projects.html
+++ b/staging/stuhood-release-notes-per-branch/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/notes-1.0.x.html
+++ b/staging/stuhood-release-notes-per-branch/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/notes-master.html
+++ b/staging/stuhood-release-notes-per-branch/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/options.html
+++ b/staging/stuhood-release-notes-per-branch/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/options_reference.html
+++ b/staging/stuhood-release-notes-per-branch/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/page.html
+++ b/staging/stuhood-release-notes-per-branch/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/powered_by.html
+++ b/staging/stuhood-release-notes-per-branch/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/publish.html
+++ b/staging/stuhood-release-notes-per-branch/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/python_readme.html
+++ b/staging/stuhood-release-notes-per-branch/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/release.html
+++ b/staging/stuhood-release-notes-per-branch/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/release_jvm.html
+++ b/staging/stuhood-release-notes-per-branch/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/release_strategy.html
+++ b/staging/stuhood-release-notes-per-branch/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/reporting_server.html
+++ b/staging/stuhood-release-notes-per-branch/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/scala.html
+++ b/staging/stuhood-release-notes-per-branch/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/setup_repo.html
+++ b/staging/stuhood-release-notes-per-branch/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/styleguide.html
+++ b/staging/stuhood-release-notes-per-branch/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/target_addresses.html
+++ b/staging/stuhood-release-notes-per-branch/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/thrift_deps.html
+++ b/staging/stuhood-release-notes-per-branch/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/tshoot.html
+++ b/staging/stuhood-release-notes-per-branch/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-notes-per-branch/why_use_pants.html
+++ b/staging/stuhood-release-notes-per-branch/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/1.0.html
+++ b/staging/stuhood-release-strategy/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/3rdparty.html
+++ b/staging/stuhood-release-strategy/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/3rdparty_jvm.html
+++ b/staging/stuhood-release-strategy/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/3rdparty_py.html
+++ b/staging/stuhood-release-strategy/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/announce_201409.html
+++ b/staging/stuhood-release-strategy/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/branching_strategy.html
+++ b/staging/stuhood-release-strategy/branching_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/build_dictionary.html
+++ b/staging/stuhood-release-strategy/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/build_files.html
+++ b/staging/stuhood-release-strategy/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/changelog.html
+++ b/staging/stuhood-release-strategy/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/community.html
+++ b/staging/stuhood-release-strategy/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/deprecation_policy.html
+++ b/staging/stuhood-release-strategy/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/dev.html
+++ b/staging/stuhood-release-strategy/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/dev_tasks.html
+++ b/staging/stuhood-release-strategy/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/dev_tasks_publish_extras.html
+++ b/staging/stuhood-release-strategy/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/docs.html
+++ b/staging/stuhood-release-strategy/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/export.html
+++ b/staging/stuhood-release-strategy/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/first_concepts.html
+++ b/staging/stuhood-release-strategy/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/first_tutorial.html
+++ b/staging/stuhood-release-strategy/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/from_maven.html
+++ b/staging/stuhood-release-strategy/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/go_readme.html
+++ b/staging/stuhood-release-strategy/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/howto_ask.html
+++ b/staging/stuhood-release-strategy/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/howto_contribute.html
+++ b/staging/stuhood-release-strategy/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/howto_develop.html
+++ b/staging/stuhood-release-strategy/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/howto_plugin.html
+++ b/staging/stuhood-release-strategy/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/ide_support.html
+++ b/staging/stuhood-release-strategy/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/index.html
+++ b/staging/stuhood-release-strategy/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/install.html
+++ b/staging/stuhood-release-strategy/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/intellij.html
+++ b/staging/stuhood-release-strategy/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/internals.html
+++ b/staging/stuhood-release-strategy/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/invoking.html
+++ b/staging/stuhood-release-strategy/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/jvm_projects.html
+++ b/staging/stuhood-release-strategy/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/options.html
+++ b/staging/stuhood-release-strategy/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/options_reference.html
+++ b/staging/stuhood-release-strategy/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/page.html
+++ b/staging/stuhood-release-strategy/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/powered_by.html
+++ b/staging/stuhood-release-strategy/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/publish.html
+++ b/staging/stuhood-release-strategy/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/python_readme.html
+++ b/staging/stuhood-release-strategy/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/release.html
+++ b/staging/stuhood-release-strategy/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/release_jvm.html
+++ b/staging/stuhood-release-strategy/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/release_strategy.html
+++ b/staging/stuhood-release-strategy/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/reporting_server.html
+++ b/staging/stuhood-release-strategy/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/scala.html
+++ b/staging/stuhood-release-strategy/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/setup_repo.html
+++ b/staging/stuhood-release-strategy/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/styleguide.html
+++ b/staging/stuhood-release-strategy/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/target_addresses.html
+++ b/staging/stuhood-release-strategy/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/thrift_deps.html
+++ b/staging/stuhood-release-strategy/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/tshoot.html
+++ b/staging/stuhood-release-strategy/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-release-strategy/why_use_pants.html
+++ b/staging/stuhood-release-strategy/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/1.0.html
+++ b/staging/stuhood-scope-docs/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/3rdparty.html
+++ b/staging/stuhood-scope-docs/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/3rdparty_jvm.html
+++ b/staging/stuhood-scope-docs/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/3rdparty_py.html
+++ b/staging/stuhood-scope-docs/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/announce_201409.html
+++ b/staging/stuhood-scope-docs/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/build_dictionary.html
+++ b/staging/stuhood-scope-docs/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/build_files.html
+++ b/staging/stuhood-scope-docs/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/changelog.html
+++ b/staging/stuhood-scope-docs/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/community.html
+++ b/staging/stuhood-scope-docs/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/deprecation_policy.html
+++ b/staging/stuhood-scope-docs/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/dev.html
+++ b/staging/stuhood-scope-docs/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/dev_tasks.html
+++ b/staging/stuhood-scope-docs/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/dev_tasks_publish_extras.html
+++ b/staging/stuhood-scope-docs/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/docs.html
+++ b/staging/stuhood-scope-docs/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/export.html
+++ b/staging/stuhood-scope-docs/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/first_concepts.html
+++ b/staging/stuhood-scope-docs/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/first_tutorial.html
+++ b/staging/stuhood-scope-docs/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/from_maven.html
+++ b/staging/stuhood-scope-docs/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/go_readme.html
+++ b/staging/stuhood-scope-docs/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/howto_ask.html
+++ b/staging/stuhood-scope-docs/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/howto_contribute.html
+++ b/staging/stuhood-scope-docs/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/howto_develop.html
+++ b/staging/stuhood-scope-docs/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/howto_plugin.html
+++ b/staging/stuhood-scope-docs/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/ide_support.html
+++ b/staging/stuhood-scope-docs/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/index.html
+++ b/staging/stuhood-scope-docs/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/install.html
+++ b/staging/stuhood-scope-docs/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/intellij.html
+++ b/staging/stuhood-scope-docs/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/internals.html
+++ b/staging/stuhood-scope-docs/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/invoking.html
+++ b/staging/stuhood-scope-docs/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/jvm_projects.html
+++ b/staging/stuhood-scope-docs/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/notes-1.0.x.html
+++ b/staging/stuhood-scope-docs/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/notes-master.html
+++ b/staging/stuhood-scope-docs/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/options.html
+++ b/staging/stuhood-scope-docs/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/options_reference.html
+++ b/staging/stuhood-scope-docs/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/page.html
+++ b/staging/stuhood-scope-docs/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/powered_by.html
+++ b/staging/stuhood-scope-docs/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/publish.html
+++ b/staging/stuhood-scope-docs/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/python_readme.html
+++ b/staging/stuhood-scope-docs/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/release.html
+++ b/staging/stuhood-scope-docs/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/release_jvm.html
+++ b/staging/stuhood-scope-docs/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/release_strategy.html
+++ b/staging/stuhood-scope-docs/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/reporting_server.html
+++ b/staging/stuhood-scope-docs/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/scala.html
+++ b/staging/stuhood-scope-docs/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/setup_repo.html
+++ b/staging/stuhood-scope-docs/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/styleguide.html
+++ b/staging/stuhood-scope-docs/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/target_addresses.html
+++ b/staging/stuhood-scope-docs/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/thrift_deps.html
+++ b/staging/stuhood-scope-docs/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/tshoot.html
+++ b/staging/stuhood-scope-docs/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/stuhood-scope-docs/why_use_pants.html
+++ b/staging/stuhood-scope-docs/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/1.0.html
+++ b/staging/yic/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/3rdparty.html
+++ b/staging/yic/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/3rdparty_jvm.html
+++ b/staging/yic/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/3rdparty_py.html
+++ b/staging/yic/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/alias.html
+++ b/staging/yic/alias.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/announce_201409.html
+++ b/staging/yic/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/blog.html
+++ b/staging/yic/blog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/build_dictionary.html
+++ b/staging/yic/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/build_files.html
+++ b/staging/yic/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/bundle.html
+++ b/staging/yic/bundle.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/changelog.html
+++ b/staging/yic/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/clean.html
+++ b/staging/yic/clean.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/cli_args.html
+++ b/staging/yic/cli_args.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/committers.html
+++ b/staging/yic/committers.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/common_tasks.html
+++ b/staging/yic/common_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/community.html
+++ b/staging/yic/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/compile.html
+++ b/staging/yic/compile.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/coursier_migration.html
+++ b/staging/yic/coursier_migration.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/dependencies.html
+++ b/staging/yic/dependencies.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/deprecation_policy.html
+++ b/staging/yic/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/dev.html
+++ b/staging/yic/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/dev_tasks.html
+++ b/staging/yic/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/dev_tasks_publish_extras.html
+++ b/staging/yic/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/docs.html
+++ b/staging/yic/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/export.html
+++ b/staging/yic/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/file_bundles.html
+++ b/staging/yic/file_bundles.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/first_concepts.html
+++ b/staging/yic/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/first_tutorial.html
+++ b/staging/yic/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/from_maven.html
+++ b/staging/yic/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/globs.html
+++ b/staging/yic/globs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/go_readme.html
+++ b/staging/yic/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/howto_ask.html
+++ b/staging/yic/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/howto_contribute.html
+++ b/staging/yic/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/howto_develop.html
+++ b/staging/yic/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/howto_plugin.html
+++ b/staging/yic/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/ide_support.html
+++ b/staging/yic/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/index.html
+++ b/staging/yic/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/install.html
+++ b/staging/yic/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/intellij.html
+++ b/staging/yic/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/internals.html
+++ b/staging/yic/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/invoking.html
+++ b/staging/yic/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/javac_plugins.html
+++ b/staging/yic/javac_plugins.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/jvm_binary.html
+++ b/staging/yic/jvm_binary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/jvm_library.html
+++ b/staging/yic/jvm_library.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/jvm_options.html
+++ b/staging/yic/jvm_options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/jvm_projects.html
+++ b/staging/yic/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/jvm_tests.html
+++ b/staging/yic/jvm_tests.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/list_goals.html
+++ b/staging/yic/list_goals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/list_targets.html
+++ b/staging/yic/list_targets.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/notes-1.0.x.html
+++ b/staging/yic/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/notes-1.1.x.html
+++ b/staging/yic/notes-1.1.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/notes-1.2.x.html
+++ b/staging/yic/notes-1.2.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/notes-1.3.x.html
+++ b/staging/yic/notes-1.3.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/notes-1.4.x.html
+++ b/staging/yic/notes-1.4.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/notes-1.5.x.html
+++ b/staging/yic/notes-1.5.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/notes-1.6.x.html
+++ b/staging/yic/notes-1.6.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/notes-1.7.x.html
+++ b/staging/yic/notes-1.7.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/notes-1.8.x.html
+++ b/staging/yic/notes-1.8.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/notes-1.9.x.html
+++ b/staging/yic/notes-1.9.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/notes-master.html
+++ b/staging/yic/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/options.html
+++ b/staging/yic/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/options_reference.html
+++ b/staging/yic/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/orgs.html
+++ b/staging/yic/orgs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/page.html
+++ b/staging/yic/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/pex.html
+++ b/staging/yic/pex.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/powered_by.html
+++ b/staging/yic/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/publish.html
+++ b/staging/yic/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/python_library.html
+++ b/staging/yic/python_library.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/python_readme.html
+++ b/staging/yic/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/python_tests.html
+++ b/staging/yic/python_tests.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/release.html
+++ b/staging/yic/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/release_jvm.html
+++ b/staging/yic/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/release_strategy.html
+++ b/staging/yic/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/repl.html
+++ b/staging/yic/repl.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/reporting_server.html
+++ b/staging/yic/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/resources.html
+++ b/staging/yic/resources.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/run.html
+++ b/staging/yic/run.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/scala.html
+++ b/staging/yic/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/scalac_plugins.html
+++ b/staging/yic/scalac_plugins.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/server.html
+++ b/staging/yic/server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/setup_repo.html
+++ b/staging/yic/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/styleguide.html
+++ b/staging/yic/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/target_addresses.html
+++ b/staging/yic/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/test.html
+++ b/staging/yic/test.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/test_suite.html
+++ b/staging/yic/test_suite.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/thrift_deps.html
+++ b/staging/yic/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/thrift_gen.html
+++ b/staging/yic/thrift_gen.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/tshoot.html
+++ b/staging/yic/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/yic/why_use_pants.html
+++ b/staging/yic/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/1.0.html
+++ b/staging/zundel/1.0.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/3rdparty.html
+++ b/staging/zundel/3rdparty.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/3rdparty_jvm.html
+++ b/staging/zundel/3rdparty_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/3rdparty_py.html
+++ b/staging/zundel/3rdparty_py.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/announce_201409.html
+++ b/staging/zundel/announce_201409.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/branching_strategy.html
+++ b/staging/zundel/branching_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/build_dictionary.html
+++ b/staging/zundel/build_dictionary.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/build_files.html
+++ b/staging/zundel/build_files.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/changelog.html
+++ b/staging/zundel/changelog.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/committers.html
+++ b/staging/zundel/committers.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/community.html
+++ b/staging/zundel/community.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/deprecation_policy.html
+++ b/staging/zundel/deprecation_policy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/dev.html
+++ b/staging/zundel/dev.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/dev_tasks.html
+++ b/staging/zundel/dev_tasks.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/dev_tasks_publish_extras.html
+++ b/staging/zundel/dev_tasks_publish_extras.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/docs.html
+++ b/staging/zundel/docs.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/export.html
+++ b/staging/zundel/export.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/first_concepts.html
+++ b/staging/zundel/first_concepts.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/first_tutorial.html
+++ b/staging/zundel/first_tutorial.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/from_maven.html
+++ b/staging/zundel/from_maven.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/go_readme.html
+++ b/staging/zundel/go_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/howto_ask.html
+++ b/staging/zundel/howto_ask.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/howto_contribute.html
+++ b/staging/zundel/howto_contribute.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/howto_develop.html
+++ b/staging/zundel/howto_develop.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/howto_plugin.html
+++ b/staging/zundel/howto_plugin.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/ide_support.html
+++ b/staging/zundel/ide_support.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/index.html
+++ b/staging/zundel/index.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/install.html
+++ b/staging/zundel/install.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/intellij.html
+++ b/staging/zundel/intellij.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/internals.html
+++ b/staging/zundel/internals.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/invoking.html
+++ b/staging/zundel/invoking.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/jvm_projects.html
+++ b/staging/zundel/jvm_projects.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/notes-1.0.x.html
+++ b/staging/zundel/notes-1.0.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/notes-1.1.x.html
+++ b/staging/zundel/notes-1.1.x.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/notes-master.html
+++ b/staging/zundel/notes-master.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/options.html
+++ b/staging/zundel/options.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/options_reference.html
+++ b/staging/zundel/options_reference.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/page.html
+++ b/staging/zundel/page.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/powered_by.html
+++ b/staging/zundel/powered_by.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/publish.html
+++ b/staging/zundel/publish.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/python_readme.html
+++ b/staging/zundel/python_readme.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/release.html
+++ b/staging/zundel/release.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/release_jvm.html
+++ b/staging/zundel/release_jvm.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/release_strategy.html
+++ b/staging/zundel/release_strategy.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/reporting_server.html
+++ b/staging/zundel/reporting_server.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/scala.html
+++ b/staging/zundel/scala.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/setup_repo.html
+++ b/staging/zundel/setup_repo.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/styleguide.html
+++ b/staging/zundel/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/target_addresses.html
+++ b/staging/zundel/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/thrift_deps.html
+++ b/staging/zundel/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/tshoot.html
+++ b/staging/zundel/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/staging/zundel/why_use_pants.html
+++ b/staging/zundel/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/styleguide.html
+++ b/styleguide.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/target_addresses.html
+++ b/target_addresses.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/target_aggregate.html
+++ b/target_aggregate.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/test.html
+++ b/test.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/test_suite.html
+++ b/test_suite.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/thrift_deps.html
+++ b/thrift_deps.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/thrift_gen.html
+++ b/thrift_gen.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/tshoot.html
+++ b/tshoot.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 

--- a/why_use_pants.html
+++ b/why_use_pants.html
@@ -35,7 +35,7 @@
           <img src="pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 


### PR DESCRIPTION
The only manual edit was to the .css file.

The html files were edited via sed:

```
$ find . -type f -name "*.html" | xargs -n1 sed -i '' -n '1h;1!H;${g;s/<a class="navbar-brand" href="index.html">\n          Pants/<a class="navbar-brand" href="index.html">\n          Pants v1/;p;}' 

$ find . -type f -name "*.html" | xargs -n1 sed -i '' -n '1h;1!H;${g;s/  <\/nav>/    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https:\/\/www.pantsbuild.org\/">here<\/a> for the Pants v2 documentation.<\/div>\n  <\/nav>/;p;}'
```
